### PR TITLE
chore: Add REUSE information to README

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -31,5 +31,5 @@ Files:
     fixtures/.gitkeep
     README.md
     .gitignore
-Copyright: 2020 SAP SE or an SAP affiliate company and Cloud Security Client Go contributors
+Copyright: 2020-2021 SAP SE or an SAP affiliate company and cloud-authorization-buildpack contributors
 License: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-### Buildpack User Documentation
+# Buildpack User Documentation
 
-### Building the Buildpack
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/cloud-authorization-buildpack)](https://api.reuse.software/info/github.com/SAP/cloud-authorization-buildpack)
+
+## Building the Buildpack
 To build this buildpack, run the following command from the buildpack's directory:
 
 1. Source the .envrc file in the buildpack directory.
@@ -27,7 +29,7 @@ cf create-buildpack [BUILDPACK_NAME] [BUILDPACK_ZIP_FILE_PATH] 1
 cf push my_app [-b BUILDPACK_NAME]
 ```
 
-### Testing
+## Testing
 Buildpacks use the [Cutlass](https://github.com/cloudfoundry/libbuildpack/cutlass) framework for running integration tests.
 
 To test this buildpack, run the following command from the buildpack's directory:
@@ -53,8 +55,11 @@ To simplify the process in the future, install [direnv](https://direnv.net/) whi
 
 More information can be found on Github [cutlass](https://github.com/cloudfoundry/libbuildpack/cutlass).
 
-### Reporting Issues
+## Reporting Issues
 Open an issue on this project
 
 ## Disclaimer
 This buildpack is experimental and not yet intended for production use.
+
+## Licensing
+Copyright 2020-2021 SAP SE or an SAP affiliate company and cloud-authorization-buildpack contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/cloud-authorization-buildpack).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR adds the REUSE Tool links to the README

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #10 and #11)
- Please change the .reuse/dep5 file so that all files are covered by the REUSE tool. Currently this is not the case.. Edits by maintainers are enabled in this PR in case you want to do it with this PR.

Fixes #9