### PR TITLE
Log body if DCL upload fails

### DIFF
--- a/pkg/supply/supply_test.go
+++ b/pkg/supply/supply_test.go
@@ -203,18 +203,35 @@ var _ = Describe("Supply", func() {
 			})
 		})
 		When("the AMS server returns an error", func() {
-			BeforeEach(func() {
-				mockAMSClient = NewMockAMSClient(mockCtrl)
-				mockAMSClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-					uploadReqSpy = req
-					return &http.Response{StatusCode: 400, Body: io.NopCloser(strings.NewReader("your policy is broken"))}, nil
-				}).AnyTimes()
+			Context("400", func() {
+				BeforeEach(func() {
+					mockAMSClient = NewMockAMSClient(mockCtrl)
+					mockAMSClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+						uploadReqSpy = req
+						return &http.Response{StatusCode: 400, Body: io.NopCloser(strings.NewReader("your policy is broken"))}, nil
+					}).AnyTimes()
 
+				})
+				It("should log the response body", func() {
+					err := supplier.Run()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("your policy is broken"))
+				})
 			})
-			It("should log the response body", func() {
-				err := supplier.Run()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("your policy is broken"))
+			Context("401", func() {
+				BeforeEach(func() {
+					mockAMSClient = NewMockAMSClient(mockCtrl)
+					mockAMSClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+						uploadReqSpy = req
+						return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader("your policy is broken"))}, nil
+					}).AnyTimes()
+
+				})
+				It("should log the response body", func() {
+					err := supplier.Run()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("your policy is broken"))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
   * Fix bug where body was always empty in error log
  * Fix typo in what used to be line 42 (!= vs ==), causing body never to be unmarshalled
  * Add test to ensure body is logged on non-400 error code