### PR TITLE
Add health bundle

### DIFF
--- a/pkg/supply/supply.go
+++ b/pkg/supply/supply.go
@@ -78,16 +78,16 @@ func (s *Supplier) Run() error {
 	if err != nil {
 		return fmt.Errorf("could not load AMSCredentials: %w", err)
 	}
-	if err := s.supplyOPABinary(); err != nil {
+	if err = s.supplyOPABinary(); err != nil {
 		return fmt.Errorf("could not supply opa binary: %w", err)
 	}
-	if err := s.writeLaunchConfig(cfg); err != nil {
+	if err = s.writeLaunchConfig(cfg); err != nil {
 		return fmt.Errorf("could not write launch config: %w", err)
 	}
-	if err := s.writeOpaConfig(amsCreds.ObjectStore); err != nil {
+	if err = s.writeOpaConfig(amsCreds.ObjectStore); err != nil {
 		return fmt.Errorf("could not write opa config: %w", err)
 	}
-	if err := s.writeProfileDFile(cfg, amsCreds); err != nil {
+	if err = s.writeProfileDFile(cfg, amsCreds); err != nil {
 		return fmt.Errorf("could not write profileD file: %w", err)
 	}
 	if cfg.shouldUpload {

--- a/pkg/supply/supply_test.go
+++ b/pkg/supply/supply_test.go
@@ -118,11 +118,16 @@ var _ = Describe("Supply", func() {
 				Expect(ld.Processes).To(HaveLen(1))
 				Expect(ld.Processes[0].Type).To(Equal("opa"))
 				Expect(ld.Processes[0].Platforms.Cloudfoundry.SidecarFor).To(Equal([]string{"web"}))
-				cmd := `"$DEPS_DIR/42/opa" run -s -c "$DEPS_DIR/42/opa_config.yml" -l 'info' -a '[]:9888' --skip-version-check`
+				cmd := `"$DEPS_DIR/42/opa" run -s -b "$DEPS_DIR/42/healthBundle" -c "$DEPS_DIR/42/opa_config.yml" -l 'info' -a '[]:9888' --skip-version-check`
 				Expect(ld.Processes[0].Command).To(Equal(cmd))
 				Expect(ld.Processes[0].Limits.Memory).To(Equal(100))
 				Expect(buffer.String()).To(ContainSubstring("writing launch.yml"))
 			})
+		})
+		It("adds the health bundle", func() {
+			Expect(supplier.Run()).To(Succeed())
+			Expect(filepath.Join(depDir, "healthBundle", "system", "health", "health.rego")).To(BeARegularFile())
+			Expect(filepath.Join(depDir, "healthBundle", ".manifest")).To(BeARegularFile())
 		})
 		It("creates the correct opa config", func() {
 			Expect(supplier.Run()).To(Succeed())

--- a/resources/healthBundle/.manifest
+++ b/resources/healthBundle/.manifest
@@ -1,0 +1,1 @@
+{"revision":"1","roots":["system"]}

--- a/resources/healthBundle/system/health/health.rego
+++ b/resources/healthBundle/system/health/health.rego
@@ -1,0 +1,15 @@
+#SPDX-FileCopyrightText: 2020 The OPA Authors
+#
+#SPDX-License-Identifier: Apache-2.0
+package system.health
+
+# opa is live if it can process this rule
+default live = true
+
+# by default, opa is not ready
+default ready = false
+
+# opa is ready once all plugins have reported OK at least once
+ready {
+  input.plugins_ready
+}


### PR DESCRIPTION
Adds an additional bundle at start up that adds endpoints for [custom health checks](https://www.openpolicyagent.org/docs/latest/rest-api/#custom-health-checks).
More specifically, it adds `/health/ready` and `/health/live` to be used for readiness/liveness probes.

We need these endpoints, since the conventional endpoint (/health) is not suitable for readiness probes in combination with a discovery bundle (will temporarily return 500, if new bundle is added).

The PR also contains a minor fix (removes unnecessary ":").