### PR TITLE
Make OPA persist bundles

### DIFF
--- a/pkg/supply/supply.go
+++ b/pkg/supply/supply.go
@@ -142,6 +142,7 @@ func (s *Supplier) writeOpaConfig(osCreds ObjectStoreCredentials) error {
 	serviceKey := "s3"
 	bundles := make(map[string]*bundle.Source)
 	bundles["SAP"] = &bundle.Source{
+		Persist: true,
 		Config: download.Config{
 			Polling: download.PollingConfig{
 				MinDelaySeconds: newInt64P(10),

--- a/pkg/supply/supply_test.go
+++ b/pkg/supply/supply_test.go
@@ -142,6 +142,7 @@ var _ = Describe("Supply", func() {
 				serviceKey = bundleConfig["SAP"].Service
 				Expect(serviceKey).NotTo(BeEmpty())
 				Expect(bundleConfig["SAP"].Resource).To(Equal("SAP.tar.gz"))
+				Expect(bundleConfig["SAP"].Persist).To(BeTrue())
 				Expect(*bundleConfig["SAP"].Polling.MinDelaySeconds).To(Equal(int64(10)))
 				Expect(*bundleConfig["SAP"].Polling.MaxDelaySeconds).To(Equal(int64(20)))
 			})


### PR DESCRIPTION
  - this way OPAs on K8s can restart even if the bundle provider is down