### PR TITLE
Set default OPA log level to "info"

### DIFF
--- a/pkg/supply/supply.go
+++ b/pkg/supply/supply.go
@@ -260,7 +260,7 @@ func (s *Supplier) loadBuildpackConfig(log *libbuildpack.Logger) (config, error)
 	}
 	logLevel := os.Getenv("AMS_LOG_LEVEL")
 	if logLevel == "" {
-		logLevel = "info"
+		logLevel = "error"
 	}
 	return config{
 		serviceName:  serviceName,


### PR DESCRIPTION
Since the business application is supposed to handle audit logging, OPA should only log errors.
For debugging, the log level can be set to `debug` or `info` via `AMS_LOG_LEVEL`.