### PR TITLE
Use constant OPA path

### DIFF
--- a/pkg/supply/supply.go
+++ b/pkg/supply/supply.go
@@ -206,8 +206,8 @@ func (s *Supplier) createStorageGatewayConfig(cred AMSCredentials) OPAConfig {
 	services[serviceKey] = RestConfig{
 		URL: cred.BundleURL,
 		Credentials: Credentials{ClientTLS: &ClientTLS{
-			Cert: "/home/vcap/deps/0/ias.crt",
-			Key:  "/home/vcap/deps/0/ias.key",
+			Cert: path.Join("/home/vcap/deps/", s.Stager.DepsIdx(), "ias.crt"),
+			Key:  path.Join("/home/vcap/deps/", s.Stager.DepsIdx(), "ias.key"),
 		}},
 	}
 
@@ -220,7 +220,7 @@ func (s *Supplier) createStorageGatewayConfig(cred AMSCredentials) OPAConfig {
 func (s *Supplier) writeLaunchConfig(cfg config) error {
 	s.Log.Info("writing launch.yml..")
 	cmd := fmt.Sprintf(
-		"\"$DEPS_DIR/%s\" run -s -c \"$DEPS_DIR/%s\" -l '%s' -a '127.0.0.1:%d' --skip-version-check",
+		`"/home/vcap/deps/%s" run -s -c "/home/vcap/deps/%s" -l '%s' -a '127.0.0.1:%d' --skip-version-check`,
 		path.Join(s.Stager.DepsIdx(), "opa"),
 		path.Join(s.Stager.DepsIdx(), "opa_config.yml"),
 		cfg.logLevel,

--- a/pkg/supply/supply_test.go
+++ b/pkg/supply/supply_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Supply", func() {
 				Expect(ld.Processes).To(HaveLen(1))
 				Expect(ld.Processes[0].Type).To(Equal("opa"))
 				Expect(ld.Processes[0].Platforms.Cloudfoundry.SidecarFor).To(Equal([]string{"web"}))
-				cmd := `"$DEPS_DIR/42/opa" run -s -c "$DEPS_DIR/42/opa_config.yml" -l 'error' -a '127.0.0.1:9888' --skip-version-check`
+				cmd := `"/home/vcap/deps/42/opa" run -s -c "/home/vcap/deps/42/opa_config.yml" -l 'error' -a '127.0.0.1:9888' --skip-version-check`
 				Expect(ld.Processes[0].Command).To(Equal(cmd))
 				Expect(ld.Processes[0].Limits.Memory).To(Equal(100))
 				Expect(buffer.String()).To(ContainSubstring("writing launch.yml"))
@@ -314,8 +314,8 @@ var _ = Describe("Supply", func() {
 					Expect(err).NotTo(HaveOccurred())
 					By("specifying ClientTLS", func() {
 						Expect(restConfig).To(HaveKey("bundle_storage"))
-						Expect(restConfig["bundle_storage"].Credentials.ClientTLS.Cert).To(Equal("/home/vcap/deps/0/ias.crt"))
-						Expect(restConfig["bundle_storage"].Credentials.ClientTLS.PrivateKey).To(Equal("/home/vcap/deps/0/ias.key"))
+						Expect(restConfig["bundle_storage"].Credentials.ClientTLS.Cert).To(Equal("/home/vcap/deps/42/ias.crt"))
+						Expect(restConfig["bundle_storage"].Credentials.ClientTLS.PrivateKey).To(Equal("/home/vcap/deps/42/ias.key"))
 						Expect(restConfig["bundle_storage"].URL).To(Equal("https://my-bundle-gateway.org/some/path"))
 					})
 					By("making sure there's only one auth method", func() {


### PR DESCRIPTION
  * According to https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html#droplet-filesystem the droplet filesystem is always /home/vcap
  * Remove env templating from launch.yml
  * Use depIdx for storing TLS config in case buildpack is not #0