### PR TITLE
Add retries to uploader

### DIFF
--- a/pkg/supply/supply_test.go
+++ b/pkg/supply/supply_test.go
@@ -246,6 +246,23 @@ var _ = Describe("Supply", func() {
 					Expect(err.Error()).To(ContainSubstring("your policy is broken"))
 				})
 			})
+			Context("403 (proof-token endpoint not ready)", func() {
+				BeforeEach(func() {
+					uploader.RetryPeriod = time.Millisecond * 10
+					mockAMSClient = NewMockAMSClient(mockCtrl)
+					gomock.InOrder(
+						mockAMSClient.EXPECT().Do(gomock.Any()).Return(&http.Response{StatusCode: 403, Body: io.NopCloser(strings.NewReader("could not find certificate"))}, nil),
+						mockAMSClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+							uploadReqSpy = req
+							return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))}, nil
+						}))
+				})
+				It("retries", func() {
+					Expect(supplier.Run()).To(Succeed())
+					Expect(writtenLogs.String()).To(ContainSubstring("retrying after"))
+					Expect(uploadReqSpy.Body).NotTo(BeNil())
+				})
+			})
 		})
 		When("AMS_LOG_LEVEL is set to info", func() {
 			BeforeEach(func() { os.Setenv("AMS_LOG_LEVEL", "info") })

--- a/pkg/supply/supply_test.go
+++ b/pkg/supply/supply_test.go
@@ -231,27 +231,12 @@ var _ = Describe("Supply", func() {
 					Expect(err.Error()).To(ContainSubstring("your policy is broken"))
 				})
 			})
-			Context("401", func() {
-				BeforeEach(func() {
-					mockAMSClient = NewMockAMSClient(mockCtrl)
-					mockAMSClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-						uploadReqSpy = req
-						return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader("your policy is broken"))}, nil
-					}).AnyTimes()
-
-				})
-				It("should log the response body", func() {
-					err := supplier.Run()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("your policy is broken"))
-				})
-			})
-			Context("403 (proof-token endpoint not ready)", func() {
+			Context("401 (proof-token endpoint not ready)", func() {
 				BeforeEach(func() {
 					uploader.RetryPeriod = time.Millisecond * 10
 					mockAMSClient = NewMockAMSClient(mockCtrl)
 					gomock.InOrder(
-						mockAMSClient.EXPECT().Do(gomock.Any()).Return(&http.Response{StatusCode: 403, Body: io.NopCloser(strings.NewReader("could not find certificate"))}, nil),
+						mockAMSClient.EXPECT().Do(gomock.Any()).Return(&http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader("could not find certificate"))}, nil),
 						mockAMSClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
 							uploadReqSpy = req
 							return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))}, nil

--- a/pkg/uploader/archiver.go
+++ b/pkg/uploader/archiver.go
@@ -21,7 +21,7 @@ type archiveContent struct {
 	file   string
 }
 
-func CreateArchive(log *libbuildpack.Logger, root string) (io.Reader, error) {
+func CreateArchive(log *libbuildpack.Logger, root string) (*bytes.Buffer, error) {
 	var buf bytes.Buffer
 	zr := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(zr)

--- a/pkg/uploader/uploader.go
+++ b/pkg/uploader/uploader.go
@@ -71,7 +71,7 @@ func (up *Uploader) DoWithRetries(url string, body []byte, maxRetries int) (*htt
 		return nil, fmt.Errorf("DCL upload request unsuccessful: %w", err)
 	}
 	retries := 0
-	for resp.StatusCode == http.StatusForbidden && retries < maxRetries {
+	for resp.StatusCode == http.StatusUnauthorized && retries < maxRetries {
 		if err := drainResponseBody(resp.Body); err != nil {
 			return nil, fmt.Errorf("cannot drain response body: %w", err)
 		}


### PR DESCRIPTION
  * in case upstream returns 403 due to caching issues with the prooftoken endpoint