### PR TITLE
Construct up-/download URLs from identity binding

### DIFF
--- a/pkg/supply/services/amsCredentials.go
+++ b/pkg/supply/services/amsCredentials.go
@@ -40,7 +40,7 @@ func fromIdentity(log *libbuildpack.Logger) (*AMSCredentials, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not load identity credentials: %w", err)
 	}
-	if identityCreds.AuthzURL == "" {
+	if identityCreds.AuthzInstanceID == "" {
 		return nil, nil
 	}
 	validate := validator.New()

--- a/pkg/supply/services/services.go
+++ b/pkg/supply/services/services.go
@@ -60,7 +60,6 @@ type IASCredentials struct {
 
 type UnifiedIdentityCredentials struct {
 	IASCredentials
-	AuthzURL        string `json:"authorization_url" validate:"required"`
 	AuthzInstanceID string `json:"authorization_instance_id" validate:"required"`
 }
 

--- a/pkg/supply/services/services.go
+++ b/pkg/supply/services/services.go
@@ -60,10 +60,8 @@ type IASCredentials struct {
 
 type UnifiedIdentityCredentials struct {
 	IASCredentials
-	AuthzURL         string                  `json:"authorization_url" validate:"required"`
-	AuthzBundleURL   string                  `json:"authorization_bundle_url" validate:"required_without=AuthzObjectStore"`
-	AuthzObjectStore *ObjectStoreCredentials `json:"authorization_object_store" validate:"required_without=AuthzBundleURL"`
-	AuthzInstanceID  string                  `json:"authorization_instance_id" validate:"required"`
+	AuthzURL        string `json:"authorization_url" validate:"required"`
+	AuthzInstanceID string `json:"authorization_instance_id" validate:"required"`
 }
 
 func LoadService(log *libbuildpack.Logger, serviceName string) (Service, error) {


### PR DESCRIPTION
I changed the indentation of the test, that's why the change in supply_test looks larger than it actually is.