### PR TITLE
Add self-explanatory error message when service binding is missing certificate

### DIFF
--- a/pkg/supply/services/amsCredentials.go
+++ b/pkg/supply/services/amsCredentials.go
@@ -46,6 +46,9 @@ func fromIdentity(log *libbuildpack.Logger) (*AMSCredentials, error) {
 	if identityCreds.AuthzInstanceID == "" {
 		return nil, nil
 	}
+	if identityCreds.Certificate == "" || identityCreds.Key == "" { // TODO: Remove the check for KEY once X509_PROVIDED bindings are supported
+		return nil, fmt.Errorf(`invalid bindings credentials for identity service with AMS enabled: service bindings must be created with {"credential-type": "X509_GENERATED"} (more information in the identity broker documentation)`)
+	}
 	validate := validator.New()
 	err = validate.Struct(identityCreds)
 	if err != nil {


### PR DESCRIPTION
Add self-explanatory error message when service binding is missing certificate.

Previously the error message was generated only by the struct validator and looked like the following:
```
**ERROR** Error: could not load AMSCredentials: invalid binding credentials for identity service with AMS enabled: Key: 'UnifiedIdentityCredentials.IASCredentials.Certificate' Error:Field validation for 'Certificate' failed on the 'required' tag
Key: 'UnifiedIdentityCredentials.IASCredentials.Key' Error:Field validation for 'Key' failed on the 'required' tag
Failed to run all supply scripts: exit status 15
```

Stakeholders (understandably) failed to realise what was missing in order to fix the issue.