### PR TITLE
Update bundle gateway url

### DIFF
--- a/pkg/common/services/amsCredentials.go
+++ b/pkg/common/services/amsCredentials.go
@@ -68,14 +68,7 @@ func fromIdentity(log Logger) (*IASCredentials, error) {
 		return nil, fmt.Errorf("invalid binding credentials for identity service with AMS enabled: %w", err)
 	}
 
-	creds.AmsServerURL, err = url.JoinPath(creds.URL, AmsServerPath)
-	if err != nil {
-		return nil, fmt.Errorf("error building ams server url: %w", err)
-	}
-	creds.AmsBundleGatewayURL, err = url.JoinPath(creds.URL, AmsBundleGatewayPath)
-	if err != nil {
-		return nil, fmt.Errorf("error building bundle gateway url: %w", err)
-	}
+	creds.AmsServerURL = creds.URL
 
 	return &creds, nil
 }

--- a/pkg/common/services/services.go
+++ b/pkg/common/services/services.go
@@ -9,9 +9,6 @@ import (
 )
 
 const (
-	AmsServerPath        = "authorization"
-	AmsBundleGatewayPath = "bundle-gateway"
-
 	MegacliteID                   = "dwc-megaclite-ams-instance-id"
 	MegacliteAmsServerPath        = "/ams/proxy/"
 	MegacliteAmsBundleGatewayPath = "/ams/bundle/"
@@ -40,12 +37,12 @@ type IASCredentials struct {
 	URL                  string    `json:"url"`
 	ZoneUUID             string    `json:"zone_uuid"`
 
-	AmsInstanceID string `json:"authorization_instance_id"  validate:"required"`
-	AmsClientID   string `json:"authorization_client_id"`
+	AmsInstanceID       string `json:"authorization_instance_id"  validate:"required"`
+	AmsClientID         string `json:"authorization_client_id"`
+	AmsBundleGatewayURL string `json:"authorization_bundle_url"`
 
 	// derived values
-	AmsServerURL        string `json:"-"`
-	AmsBundleGatewayURL string `json:"-"`
+	AmsServerURL string `json:"-"`
 }
 
 type MegacliteCredentials struct {

--- a/pkg/supply/supply_test.go
+++ b/pkg/supply/supply_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Supply", func() {
 				})
 				By("extending the tenant host URL from the identity service", func() {
 					Expect(restConfig["bundle_storage"].URL).NotTo(ContainSubstring("megaclite.host"))
-					Expect(restConfig["bundle_storage"].URL).To(Equal("https://mytenant.accounts400.ondemand.com/bundle-gateway"))
+					Expect(restConfig["bundle_storage"].URL).To(Equal("https://mytenant.accounts400.ondemand.com/sap/ams/v1/bundles"))
 				})
 			})
 		})
@@ -234,7 +234,7 @@ var _ = Describe("Supply", func() {
 					Expect(restConfig["bundle_storage"].Credentials.ClientTLS.PrivateKey).To(Equal("/home/vcap/deps/42/ias.key"))
 				})
 				By("extending the tenant host URL from the identity service", func() {
-					Expect(restConfig["bundle_storage"].URL).To(Equal("https://mytenant.accounts400.ondemand.com/bundle-gateway"))
+					Expect(restConfig["bundle_storage"].URL).To(Equal("https://mytenant.accounts400.ondemand.com/sap/ams/v1/bundles"))
 				})
 				By("making sure there's only one auth method", func() {
 					Expect(restConfig["bundle_storage"].Credentials.S3Signing).To(BeNil())
@@ -245,7 +245,7 @@ var _ = Describe("Supply", func() {
 					Expect(string(enabled)).To(Equal(`true`))
 				})
 				By("uploading to the correct URL", func() {
-					Expect(uploadReqSpy.URL.String()).To(Equal("https://mytenant.accounts400.ondemand.com/authorization/sap/ams/v1/ams-instances/00000000-3b4d-4c41-9e5b-9aee7bfa6348/dcl-upload"))
+					Expect(uploadReqSpy.URL.String()).To(Equal("https://mytenant.accounts400.ondemand.com/sap/ams/v1/ams-instances/00000000-3b4d-4c41-9e5b-9aee7bfa6348/dcl-upload"))
 				})
 			})
 			It("creates the correct env vars", func() {

--- a/resources/testdata/bindings/env_with_ias_auth_with_client_secret.json
+++ b/resources/testdata/bindings/env_with_ias_auth_with_client_secret.json
@@ -13,9 +13,9 @@
           "uri": "s3://myawstestaccesskeyid:mysecretaccesskey@my-bucket-from-ias-svc",
           "username": "my-username"
         },
+        "authorization_bundle_url": "https://mytenant.accounts400.ondemand.com/sap/ams/v1/bundles",
+        "authorization_client_id": "205459a0-ad5d-4ac7-90e3-d058a53f7485",
         "authorization_instance_id": "847bf93c-3b4d-4c41-9e5b-9aee7bfa6348",
-        "authorization_url": "https://ams.url.from.identity/svc",
-        "authorization_ui_url": "https://4b0c2b7a-1279-4352-aasdfsadf--asdfasdf-ams-ui.authorization-dev.cfapps.ls.domain",
         "authorization_value_help_certificate_issuer": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"Locality\":[\"Walldorf\"],\"CommonName\":\"SAP Cloud Root CA\"}",
         "authorization_value_help_certificate_subject": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"OrganizationalUnit\":[\"SAP Cloud Platform Clients\",\"Canary\",\"someuid\"],\"Locality\":[\"AMS\"],\"CommonName\":\"ValueHelpmTLSCert\"}",
         "clientid": "601AED1D-0063-4B5B-8FCE-06FC75AF957C",

--- a/resources/testdata/bindings/env_with_ias_auth_x509.json
+++ b/resources/testdata/bindings/env_with_ias_auth_x509.json
@@ -14,9 +14,8 @@
           "username": "my-username"
         },
         "authorization_instance_id": "00000000-3b4d-4c41-9e5b-9aee7bfa6348",
-        "authorization_bundle_url": "https://my-bundle-gateway.org/some/path",
-        "authorization_url": "https://ams.url.from.identity/some-prefix",
-        "authorization_ui_url": "https://4b0c2b7a-1279-4352-aasdfsadf--asdfasdf-ams-ui.authorization-dev.cfapps.ls.domain",
+        "authorization_bundle_url": "https://mytenant.accounts400.ondemand.com/sap/ams/v1/bundles",
+        "authorization_client_id": "205459a0-ad5d-4ac7-90e3-d058a53f7485",
         "authorization_value_help_certificate_issuer": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"Locality\":[\"Walldorf\"],\"CommonName\":\"SAP Cloud Root CA\"}",
         "authorization_value_help_certificate_subject": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"OrganizationalUnit\":[\"SAP Cloud Platform Clients\",\"Canary\",\"someuid\"],\"Locality\":[\"AMS\"],\"CommonName\":\"ValueHelpmTLSCert\"}",
         "certificate": "identity-cert-payload",

--- a/resources/testdata/bindings/env_with_ias_auth_x509_expired.json
+++ b/resources/testdata/bindings/env_with_ias_auth_x509_expired.json
@@ -14,9 +14,8 @@
           "username": "my-username"
         },
         "authorization_instance_id": "00000000-3b4d-4c41-9e5b-9aee7bfa6348",
-        "authorization_bundle_url": "https://my-bundle-gateway.org/some/path",
-        "authorization_url": "https://ams.url.from.identity/some-prefix",
-        "authorization_ui_url": "https://4b0c2b7a-1279-4352-aasdfsadf--asdfasdf-ams-ui.authorization-dev.cfapps.ls.domain",
+        "authorization_bundle_url": "https://mytenant.accounts400.ondemand.com/sap/ams/v1/bundles",
+        "authorization_client_id": "205459a0-ad5d-4ac7-90e3-d058a53f7485",
         "authorization_value_help_certificate_issuer": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"Locality\":[\"Walldorf\"],\"CommonName\":\"SAP Cloud Root CA\"}",
         "authorization_value_help_certificate_subject": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"OrganizationalUnit\":[\"SAP Cloud Platform Clients\",\"Canary\",\"someuid\"],\"Locality\":[\"AMS\"],\"CommonName\":\"ValueHelpmTLSCert\"}",
         "certificate": "identity-cert-payload",

--- a/resources/testdata/bindings/env_with_megaclite_and_ias.json
+++ b/resources/testdata/bindings/env_with_megaclite_and_ias.json
@@ -27,9 +27,8 @@
           "username": "my-username"
         },
         "authorization_instance_id": "00000000-3b4d-4c41-9e5b-9aee7bfa6348",
-        "authorization_bundle_url": "https://my-bundle-gateway.org/some/path",
-        "authorization_url": "https://ams.url.from.identity/some-prefix",
-        "authorization_ui_url": "https://4b0c2b7a-1279-4352-aasdfsadf--asdfasdf-ams-ui.authorization-dev.cfapps.ls.domain",
+        "authorization_bundle_url": "https://mytenant.accounts400.ondemand.com/sap/ams/v1/bundles",
+        "authorization_client_id": "205459a0-ad5d-4ac7-90e3-d058a53f7485",
         "authorization_value_help_certificate_issuer": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"Locality\":[\"Walldorf\"],\"CommonName\":\"SAP Cloud Root CA\"}",
         "authorization_value_help_certificate_subject": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"OrganizationalUnit\":[\"SAP Cloud Platform Clients\",\"Canary\",\"someuid\"],\"Locality\":[\"AMS\"],\"CommonName\":\"ValueHelpmTLSCert\"}",
         "certificate": "identity-cert-payload",

--- a/resources/testdata/bindings/env_with_user_provided_service.json
+++ b/resources/testdata/bindings/env_with_user_provided_service.json
@@ -5,9 +5,8 @@
       "binding_name": null,
       "credentials": {
         "authorization_instance_id": "00000000-3b4d-4c41-9e5b-9aee7bfa6348",
-        "authorization_bundle_url": "https://my-bundle-gateway.org/some/path",
-        "authorization_url": "https://ams.url.from.identity/some-prefix",
-        "authorization_ui_url": "https://4b0c2b7a-1279-4352-aasdfsadf--asdfasdf-ams-ui.authorization-dev.cfapps.ls.domain",
+        "authorization_bundle_url": "https://mytenant.accounts400.ondemand.com/sap/ams/v1/bundles",
+        "authorization_client_id": "205459a0-ad5d-4ac7-90e3-d058a53f7485",
         "authorization_value_help_certificate_issuer": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"Locality\":[\"Walldorf\"],\"CommonName\":\"SAP Cloud Root CA\"}",
         "authorization_value_help_certificate_subject": "{\"Country\":[\"DE\"],\"Organization\":[\"SAP SE\"],\"OrganizationalUnit\":[\"SAP Cloud Platform Clients\",\"Canary\",\"someuid\"],\"Locality\":[\"AMS\"],\"CommonName\":\"ValueHelpmTLSCert\"}",
         "certificate": "identity-cert-payload",


### PR DESCRIPTION
The bundle download url is part of the service binding as `authorization_bundle_url`

For example:
`"authorization_bundle_url": "https://mytenant.accounts.ondemand.com/sap/ams/v1/bundles"`

Open: What about https://github.com/SAP/cloud-authorization-buildpack/tree/main/k8s-sidecar? 