### PR TITLE
Use only sap version in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,7 @@ dependency_deprecation_dates:
 dependencies:
   - name: sap-opa
     # 0 patch versions don't work here, see https://github.com/cloudfoundry/libbuildpack/issues/181
-    version: "0.3.7"
+    version: "0.3.7" # Using the full version causes a warning like "**WARNING** You are using the pre-release version 0.60.0-sap-0.3.7 of opa"
     file: "resources/opa.tar.gz"
     sha256: 74fdf4736efb7d9e204e9c0d972026cd18c8d083809a22c59c42207a73214034
     uri: https://github.com/SAP/cloud-authorization-buildpack/raw/main/resources/opa.tar.gz

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,11 +1,11 @@
 ---
 language: opa
 default_versions:
-  - name: opa
+  - name: sap-opa
     version: "0.3.7"
 dependency_deprecation_dates:
 dependencies:
-  - name: opa
+  - name: sap-opa
     # 0 patch versions don't work here, see https://github.com/cloudfoundry/libbuildpack/issues/181
     version: "0.3.7"
     file: "resources/opa.tar.gz"

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,12 +2,12 @@
 language: opa
 default_versions:
   - name: opa
-    version: "0.60.0-sap-0.3.7"
+    version: "0.3.7"
 dependency_deprecation_dates:
 dependencies:
   - name: opa
     # 0 patch versions don't work here, see https://github.com/cloudfoundry/libbuildpack/issues/181
-    version: "0.60.0-sap-0.3.7"
+    version: "0.3.7"
     file: "resources/opa.tar.gz"
     sha256: 74fdf4736efb7d9e204e9c0d972026cd18c8d083809a22c59c42207a73214034
     uri: https://github.com/SAP/cloud-authorization-buildpack/raw/main/resources/opa.tar.gz

--- a/pkg/supply/supply.go
+++ b/pkg/supply/supply.go
@@ -259,7 +259,7 @@ func (s *Supplier) supplyOPABinary() error {
 		return fmt.Errorf("couldn't install OPA dependency: %w", err)
 	}
 	// The packager overwrites the permissions, so we need to make it executable again
-	return os.Chmod(path.Join(s.Stager.DepDir(), opaDep.Name), 0755)
+	return os.Chmod(path.Join(s.Stager.DepDir(), "opa"), 0755)
 }
 
 func (s *Supplier) supplyCertCopier() error {

--- a/pkg/supply/supply.go
+++ b/pkg/supply/supply.go
@@ -251,7 +251,7 @@ func (s *Supplier) writeLaunchConfig(cfg env.Config) error {
 }
 
 func (s *Supplier) supplyOPABinary() error {
-	opaDep, err := s.Manifest.DefaultVersion("opa")
+	opaDep, err := s.Manifest.DefaultVersion("sap-opa")
 	if err != nil {
 		return err
 	}

--- a/pkg/uploader/archiver.go
+++ b/pkg/uploader/archiver.go
@@ -57,7 +57,7 @@ func CreateArchive(log *libbuildpack.Logger, root string) (*bytes.Buffer, error)
 		return nil, err
 	}
 
-	log.Debug("uploaded tar: %s", base64.StdEncoding.EncodeToString(buf.Bytes()))
+	log.Debug("built tar: %s", base64.StdEncoding.EncodeToString(buf.Bytes()))
 	return &buf, nil
 }
 


### PR DESCRIPTION
Use only sap version part in manifest of buildpack. Using the full version causes a warning like `**WARNING** You are using the pre-release version 0.60.0-sap-0.3.7 of opa`, because the -sap suffix is detected as a pre-release.